### PR TITLE
Fixed webview jump after multi touch gesture

### DIFF
--- a/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
+++ b/app/src/main/java/com/github/takahirom/webview_in_coodinator_layout/NestedWebView.java
@@ -82,8 +82,7 @@ public class NestedWebView extends WebView implements NestedScrollingChild {
                 // start NestedScroll
                 startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL);
                 break;
-            case MotionEvent.ACTION_UP:
-            case MotionEvent.ACTION_CANCEL:
+            default:
                 returnValue = super.onTouchEvent(event);
                 // end NestedScroll
                 stopNestedScroll();


### PR DESCRIPTION
This will prevent the webview from behaving erratically when using multi-touch gestures - however the toolbar will not move at all during multi-touch gestures like pinch to zoom.
